### PR TITLE
Stabilize failing test

### DIFF
--- a/test/main.test.js
+++ b/test/main.test.js
@@ -122,9 +122,9 @@ describe("Main", function () {
 
     it("updates version for already published environment that don't match initial preid", async () => {
       await verify(
-        "1.1.2-pre",
-        "1.1.2-ropsten.1+feature-branch-2.1234abcd7890XYZ",
-        "ropsten",
+        "0.15.0-pre",
+        "0.15.0-rc.1+feature-branch-2.1234abcd7890XYZ",
+        "rc",
         "@keep-network/tbtc"
       )
     })


### PR DESCRIPTION
The test checking if `npm-version-bump` action "updates version for
already published environment that don't match initial preid" was
unstable - was refering to actively worked on npm packages versions,
making it necessary to update the action every time new package with
that base version is released on `ropsten`.
In this commit we change the reference to different version, which is no
longer actively worked on.