### PR TITLE
Run the action on `node16`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     name: Verify committed dist directory
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Calculate hash of committed `dist` directory
         run: echo "COMMITTED_HASH=${{ hashFiles('./dist/**') }}" >> $GITHUB_ENV
@@ -34,6 +34,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: yarn install
       - run: yarn run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: yarn install
       - run: yarn run test
 
@@ -18,7 +18,7 @@ jobs:
   manual-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: mkdir ./tmp && cp ./test/data/package.json ./tmp
       - uses: ./
         id: bump-version

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ outputs:
     description: "Resolved new version"
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "./dist/index.js"
 
 branding:


### PR DESCRIPTION
Node 12 has been out of support since April 2022, as a result GitHub has started the deprecation process of Node 12 for GitHub Actions. They plan to migrate all actions to run on Node16 by Summer 2023. We update the action so that it uses the Node16.

Read more on
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

TODO after the merge:

- [ ] create a PR that for merging `v2` to `main` (?)
- [ ] tag the code with the `v2` tag